### PR TITLE
修复 Intersection Type 和 Omit 类型同时使用的时候的意外排除情况

### DIFF
--- a/src/encoder/Encoder.ts
+++ b/src/encoder/Encoder.ts
@@ -150,7 +150,7 @@ export class Encoder {
     private _write(value: any, schema: TSBufferSchema, options?: {
         skipFields?: { [fieldName: string]: 1 },
         pickFields?: { [fieldName: string]: 1 },
-        isIntersection?: boolean;
+        fromIntersection?: boolean;
         skipIndexSignature?: boolean
     }) {
         switch (schema.type) {
@@ -367,7 +367,7 @@ export class Encoder {
     private _writeInterface(value: any, schema: InterfaceTypeSchema, options?: {
         skipFields?: { [fieldName: string]: 1 },
         pickFields?: { [fieldName: string]: 1 },
-        isIntersection?: boolean,
+        fromIntersection?: boolean,
         skipIndexSignature?: boolean
     }) {
         // skipFields默认值
@@ -448,7 +448,7 @@ export class Encoder {
                 }
 
                 // SkipFields
-                if (options.skipFields[property.name] && !options.isIntersection) {
+                if (options.skipFields[property.name] && !options.fromIntersection) {
                     continue;
                 }
                 options.skipFields[property.name] = 1;
@@ -660,7 +660,7 @@ export class Encoder {
             // 编码块
             this._write(value, member.type, {
                 skipFields: skipFields,
-                isIntersection: true,
+                fromIntersection: true,
             });
             this._processIdWithLengthType(idPos, member.type);
         }

--- a/src/encoder/Encoder.ts
+++ b/src/encoder/Encoder.ts
@@ -150,6 +150,7 @@ export class Encoder {
     private _write(value: any, schema: TSBufferSchema, options?: {
         skipFields?: { [fieldName: string]: 1 },
         pickFields?: { [fieldName: string]: 1 },
+        isIntersection?: boolean;
         skipIndexSignature?: boolean
     }) {
         switch (schema.type) {
@@ -366,6 +367,7 @@ export class Encoder {
     private _writeInterface(value: any, schema: InterfaceTypeSchema, options?: {
         skipFields?: { [fieldName: string]: 1 },
         pickFields?: { [fieldName: string]: 1 },
+        isIntersection?: boolean,
         skipIndexSignature?: boolean
     }) {
         // skipFields默认值
@@ -446,7 +448,7 @@ export class Encoder {
                 }
 
                 // SkipFields
-                if (options.skipFields[property.name]) {
+                if (options.skipFields[property.name] && !options.isIntersection) {
                     continue;
                 }
                 options.skipFields[property.name] = 1;
@@ -657,7 +659,8 @@ export class Encoder {
 
             // 编码块
             this._write(value, member.type, {
-                skipFields: skipFields
+                skipFields: skipFields,
+                isIntersection: true,
             });
             this._processIdWithLengthType(idPos, member.type);
         }

--- a/test/coder/interface.test.ts
+++ b/test/coder/interface.test.ts
@@ -399,40 +399,7 @@ describe('Interface', function () {
             b: 123
         });
     })
-
-    it('Omit&', async function () {
-        let proto = await new TSBufferProtoGenerator({
-            readFile: () => `
-                export interface base {
-                    a: string;
-                    b: number;
-                    c?: { value:string };
-                    d:boolean[];
-                }
-
-                export type b = Omit<base, 'a'| 'c' | 'd'> & {a?: string};
-                export type b1 = Omit<base,'c' | 'd'>;
-            `
-        }).generate('a.ts');
-        let tsb = new TSBuffer(proto);
-
-        [
-            { a: 'xxx', b: 123 }
-        ].forEach(v => {
-
-            assert.deepStrictEqual(tsb.decode(tsb.encode(v, 'a/b').buf!, 'a/b').value, v);
-        });
-
-        [
-            { a: 'xxx', b: 123 }
-        ].forEach(v => {
-            assert.deepStrictEqual(tsb.decode(tsb.encode(v, 'a/b1').buf!, 'a/b1').value, v);
-        });
-
-        assert.deepStrictEqual(tsb.decode(tsb.encode({ a: 'xxx', b: 123 }, 'a/b').buf!, 'a/b').value, tsb.decode(tsb.encode({ a: 'xxx', b: 123 }, 'a/b1').buf!, 'a/b1').value);
-    })
-
-
+   
     it('Partial', async function () {
         let proto = await new TSBufferProtoGenerator({
             readFile: () => `
@@ -704,13 +671,3 @@ export type NonNullable4 = NonNullable<Wrapper['value4']>;
         });
     })
 })
-
-
-export type b = Omit<base, 'a'| 'c' | 'd'> & {a?: string}; 
-
-export interface base {
-                    a: string;
-                    b: number;
-                    c?: { value:string };
-                    d:boolean[];
-                }

--- a/test/coder/interface.test.ts
+++ b/test/coder/interface.test.ts
@@ -400,6 +400,39 @@ describe('Interface', function () {
         });
     })
 
+    it('Omit&', async function () {
+        let proto = await new TSBufferProtoGenerator({
+            readFile: () => `
+                export interface base {
+                    a: string;
+                    b: number;
+                    c?: { value:string };
+                    d:boolean[];
+                }
+
+                export type b = Omit<base, 'a'| 'c' | 'd'> & {a?: string};
+                export type b1 = Omit<base,'c' | 'd'>;
+            `
+        }).generate('a.ts');
+        let tsb = new TSBuffer(proto);
+
+        [
+            { a: 'xxx', b: 123 }
+        ].forEach(v => {
+
+            assert.deepStrictEqual(tsb.decode(tsb.encode(v, 'a/b').buf!, 'a/b').value, v);
+        });
+
+        [
+            { a: 'xxx', b: 123 }
+        ].forEach(v => {
+            assert.deepStrictEqual(tsb.decode(tsb.encode(v, 'a/b1').buf!, 'a/b1').value, v);
+        });
+
+        assert.deepStrictEqual(tsb.decode(tsb.encode({ a: 'xxx', b: 123 }, 'a/b').buf!, 'a/b').value, tsb.decode(tsb.encode({ a: 'xxx', b: 123 }, 'a/b1').buf!, 'a/b1').value);
+    })
+
+
     it('Partial', async function () {
         let proto = await new TSBufferProtoGenerator({
             readFile: () => `
@@ -671,3 +704,13 @@ export type NonNullable4 = NonNullable<Wrapper['value4']>;
         });
     })
 })
+
+
+export type b = Omit<base, 'a'| 'c' | 'd'> & {a?: string}; 
+
+export interface base {
+                    a: string;
+                    b: number;
+                    c?: { value:string };
+                    d:boolean[];
+                }

--- a/test/coder/logic.test.ts
+++ b/test/coder/logic.test.ts
@@ -223,4 +223,36 @@ describe('LogicTypes', function () {
 
 
     })
+
+    it('Omit & {a?: string}', async function () {
+        let proto = await new TSBufferProtoGenerator({
+            readFile: () => `
+                export interface base {
+                    a: string;
+                    b: number;
+                    c?: { value:string };
+                    d:boolean[];
+                }
+
+                export type b = Omit<base, 'a'| 'c' | 'd'> & {a?: string};
+                export type b1 = Omit<base,'c' | 'd'>;
+            `
+        }).generate('a.ts');
+        let tsb = new TSBuffer(proto);
+
+        [
+            { a: 'xxx', b: 123 }
+        ].forEach(v => {
+
+            assert.deepStrictEqual(tsb.decode(tsb.encode(v, 'a/b').buf!, 'a/b').value, v);
+        });
+
+        [
+            { a: 'xxx', b: 123 }
+        ].forEach(v => {
+            assert.deepStrictEqual(tsb.decode(tsb.encode(v, 'a/b1').buf!, 'a/b1').value, v);
+        });
+
+        assert.deepStrictEqual(tsb.decode(tsb.encode({ a: 'xxx', b: 123 }, 'a/b').buf!, 'a/b').value, tsb.decode(tsb.encode({ a: 'xxx', b: 123 }, 'a/b1').buf!, 'a/b1').value);
+    })
 })

--- a/test/coder_json/logic.test.ts
+++ b/test/coder_json/logic.test.ts
@@ -217,4 +217,36 @@ describe('LogicTypes', function () {
 
 
     })
+
+    it('Omit & {a?: string}', async function () {
+        let proto = await new TSBufferProtoGenerator({
+            readFile: () => `
+                export interface base {
+                    a: string;
+                    b: number;
+                    c?: { value:string };
+                    d:boolean[];
+                }
+
+                export type b = Omit<base, 'a'| 'c' | 'd'> & {a?: string};
+                export type b1 = Omit<base,'c' | 'd'>;
+            `
+        }).generate('a.ts');
+        let tsb = new TSBuffer(proto);
+
+        [
+            { a: 'xxx', b: 123 }
+        ].forEach(v => {
+
+            assert.deepStrictEqual(tsb.decodeJSON(tsb.encodeJSON(v, 'a/b').json!, 'a/b').value, v);
+        });
+
+        [
+            { a: 'xxx', b: 123 }
+        ].forEach(v => {
+            assert.deepStrictEqual(tsb.decodeJSON(tsb.encodeJSON(v, 'a/b1').json!, 'a/b1').value, v);
+        });
+
+        assert.deepStrictEqual(tsb.decodeJSON(tsb.encodeJSON({ a: 'xxx', b: 123 }, 'a/b').json!, 'a/b').value, tsb.decodeJSON(tsb.encodeJSON({ a: 'xxx', b: 123 }, 'a/b1').json!, 'a/b1').value);
+    })
 })


### PR DESCRIPTION
`type b = Omit<base, 'a'| 'c' | 'd'> & {a?: string};`

当 使用 Omit 是 skipFields的排除选项 会导致 interface 类型 的 合并出现意外排除的问题